### PR TITLE
Add functions that return icons/classnames based on filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,4 +17,28 @@ export function getIconForExtension(extension) {
     return `<i class="fa ${getClassNameForExtension(extension)}"></i>`
 }
 
+/**
+ * @param {string} extension
+ * @returns {string}
+ */
+export function getExtensionForFilename(filename) {
+    return filename.slice((filename.lastIndexOf('.') - 1 >>> 0) + 2)
+}
+
+/**
+ * @param {string} extension
+ * @returns {string}
+ */
+export function getClassNameForFilename(filename) {
+    return getClassNameForExtension(getExtensionForFilename(filename))
+}
+
+/**
+ * @param {string} extension
+ * @returns {string}
+ */
+export function getIconForFilename(filename) {
+    return getIconForExtension(getExtensionForFilename(filename))
+}
+
 export default getClassNameForExtension

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,11 @@
 import { assert } from 'chai'
-import { getClassNameForExtension, getIconForExtension } from '../src/index'
+import {
+    getClassNameForExtension,
+    getIconForExtension,
+    getExtensionForFilename,
+    getClassNameForFilename,
+    getIconForFilename
+} from '../src/index'
 import icons from '../src/icons'
 
 describe('icons', () => {
@@ -46,5 +52,59 @@ describe('get_icon_for_extension', () => {
     
     it('returns_the_correct_icon_for_an_extension', () => {
         assert.equal('<i class="fa fa-file-image-o"></i>', getIconForExtension('jpg'))
+    })
+})
+
+describe('get_extension_for_filename', () => {
+    
+    it('returns_the_correct_extension_for_a_filename', () => {
+        let testCases = {
+            'picture.jpg': 'jpg',
+            'audio.v1.mp3': 'mp3',
+            '.htaccess': ''
+        }
+        Object.keys(testCases).map(filename => {
+            assert.equal(testCases[filename], getExtensionForFilename(filename))
+        })
+    })
+})
+
+describe('get_class_name_for_filename', () => {
+
+    it('returns_a_default_file_icon', () => {
+        assert.equal('fa-file-o', getClassNameForFilename('file.randomExtension'))
+        assert.equal('fa-file-o', getClassNameForFilename('.htaccess'))
+    })
+
+    it('can_handle_other_cases', () => {
+        assert.equal('fa-file-image-o', getClassNameForFilename('image.JPG'))
+    })
+
+    it('returns_the_correct_class_name_for_a_filename', () => {
+        /* 
+         * Just some smoke testing, going through every single filename would be madness.
+         */
+        let testCases = {
+            'image.jpg': 'fa-file-image-o',
+            'document.pdf': 'fa-file-pdf-o',
+            'document.doc': 'fa-file-word-o',
+            'presentation.ppt': 'fa-file-powerpoint-o',
+            'spreadsheet.xls': 'fa-file-excel-o',
+            'song.mp3': 'fa-file-audio-o',
+            'song.mp4': 'fa-file-video-o',
+            'archive.zip': 'fa-file-zip-o',
+            'script.js': 'fa-file-code-o'
+        }
+
+        Object.keys(testCases).map(filename => {
+            assert.equal(testCases[filename], getClassNameForFilename(filename))
+        })
+    })
+})
+
+describe('get_icon_for_filename', () => {
+    
+    it('returns_the_correct_icon_for_a_filename', () => {
+        assert.equal('<i class="fa fa-file-image-o"></i>', getIconForFilename('image.jpg'))
     })
 })


### PR DESCRIPTION
I use this library in many places in my app.
In all of those places I had to find out the extension of the file and then use the functions in this library.

I think it makes sense to provide functions that would work with filenames.

P.S. the extension extraction function is based on answer found in: https://stackoverflow.com/questions/190852/how-can-i-get-file-extensions-with-javascript/12900504#12900504
