### PR TITLE
Add mimetypes

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -33,9 +33,7 @@ const extensions = {
     html: icons.code,
     js: icons.code,
 
-    txt: icons.text,
-
-    file: icons.file
+    txt: icons.text
 }
 
 export default extensions

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -17,6 +17,8 @@ const extensions = {
     xls: icons.excel,
     xlsx: icons.excel,
 
+    csv: icons.csv,
+
     aac: icons.audio,
     mp3: icons.audio,
     ogg: icons.audio,

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -26,8 +26,8 @@ const extensions = {
     mkv: icons.video,
     mp4: icons.video,
 
-    gz: icons.zip,
-    zip: icons.zip,
+    gz: icons.archive,
+    zip: icons.archive,
 
     css: icons.code,
     html: icons.code,

--- a/src/icons.js
+++ b/src/icons.js
@@ -4,6 +4,7 @@ const icons = {
     word: 'fa-file-word',
     powerpoint: 'fa-file-powerpoint',
     excel: 'fa-file-excel',
+    csv: 'fa-file-csv',
     audio: 'fa-file-audio',
     video: 'fa-file-video',
     archive: 'fa-file-archive',

--- a/src/icons.js
+++ b/src/icons.js
@@ -6,7 +6,7 @@ const icons = {
     excel: 'fa-file-excel',
     audio: 'fa-file-audio',
     video: 'fa-file-video',
-    zip: 'fa-file-archive',
+    archive: 'fa-file-archive',
     code: 'fa-file-code',
     text: 'fa-file-alt',
     file: 'fa-file'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import extensions from './extensions'
+import mimetypes from './mimetypes'
 import icons from './icons'
 
 /**
@@ -39,6 +40,22 @@ export function getClassNameForFilename(filename) {
  */
 export function getIconForFilename(filename) {
     return getIconForExtension(getExtensionForFilename(filename))
+}
+
+/**
+ * @param {string} mimetype
+ * @returns {string}
+ */
+export function getClassNameForMimetype(mimetype) {
+    return mimetypes[mimetype.toLowerCase()] || icons.file
+}
+
+/**
+ * @param {string} mimetype
+ * @returns {string}
+ */
+export function getIconForMimetype(mimetype) {
+    return `<i class="fa ${getClassNameForMimetype(mimetype)}"></i>`
 }
 
 export default getClassNameForExtension

--- a/src/mimetypes.js
+++ b/src/mimetypes.js
@@ -1,0 +1,45 @@
+import icons from './icons'
+
+const mimetypes = {
+    'image/gif': icons.image,
+    'image/jpeg': icons.image,
+    'image/png': icons.image,
+
+    'application/pdf': icons.pdf,
+
+    'application/msword': icons.word,
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': icons.word,
+
+    'application/mspowerpoint': icons.powerpoint,
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation': icons.powerpoint,
+
+    'application/msexcel': icons.excel,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': icons.excel,
+
+    'audio/aac': icons.audio,
+    'audio/wav': icons.audio,
+    'audio/mpeg': icons.audio,
+    'audio/mp4': icons.audio,
+    'audio/ogg': icons.audio,
+
+    'video/x-msvideo': icons.video,
+    'video/mpeg': icons.video,
+    'video/mp4': icons.video,
+    'video/ogg': icons.video,
+    'video/quicktime': icons.video,
+    'video/webm': icons.video,
+
+    'application/gzip': icons.archive,
+    'application/zip': icons.archive,
+
+    'text/css': icons.code,
+    'text/html': icons.code,
+    'text/javascript': icons.code,
+    'application/javascript': icons.code,
+
+    'text/plain': icons.text,
+    'text/richtext': icons.text,
+    'text/rtf': icons.text
+}
+
+export default mimetypes

--- a/src/mimetypes.js
+++ b/src/mimetypes.js
@@ -16,6 +16,8 @@ const mimetypes = {
     'application/msexcel': icons.excel,
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': icons.excel,
 
+    'text/csv': icons.csv,
+
     'audio/aac': icons.audio,
     'audio/wav': icons.audio,
     'audio/mpeg': icons.audio,

--- a/test/test.js
+++ b/test/test.js
@@ -13,8 +13,8 @@ import icons from '../src/icons'
 describe('icons', () => {
 
     it('returns_an_object_with_all_icons', () => {
-        assert.equal(Object.keys(icons).length, 11)
-        assert.equal(Object.values(icons).length, 11)
+        assert.equal(Object.keys(icons).length, 12)
+        assert.equal(Object.values(icons).length, 12)
     })
 })
 
@@ -41,6 +41,7 @@ describe('get_class_name_for_extension', () => {
             pptx: 'fa-file-powerpoint',
             xls: 'fa-file-excel',
             xlsx: 'fa-file-excel',
+            csv: 'fa-file-csv',
             aac: 'fa-file-audio',
             mp3: 'fa-file-audio',
             ogg: 'fa-file-audio',
@@ -145,6 +146,7 @@ describe('get_class_name_for_mimetype', () => {
             'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'fa-file-powerpoint',
             'application/msexcel': 'fa-file-excel',
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'fa-file-excel',
+            'text/csv': 'fa-file-csv',
             'audio/aac': 'fa-file-audio',
             'audio/wav': 'fa-file-audio',
             'audio/mpeg': 'fa-file-audio',

--- a/test/test.js
+++ b/test/test.js
@@ -27,20 +27,31 @@ describe('get_class_name_for_extension', () => {
     })
 
     it('returns_the_correct_class_name_for_an_extension', () => {
-        /*
-         * Just some smoke testing, going through every single extension would be madness.
-         */
         let testCases = {
+            gif: 'fa-file-image',
+            jpeg: 'fa-file-image',
             jpg: 'fa-file-image',
+            png: 'fa-file-image',
             pdf: 'fa-file-pdf',
             doc: 'fa-file-word',
+            docx: 'fa-file-word',
             ppt: 'fa-file-powerpoint',
+            pptx: 'fa-file-powerpoint',
             xls: 'fa-file-excel',
+            xlsx: 'fa-file-excel',
+            aac: 'fa-file-audio',
             mp3: 'fa-file-audio',
+            ogg: 'fa-file-audio',
+            avi: 'fa-file-video',
+            flv: 'fa-file-video',
+            mkv: 'fa-file-video',
             mp4: 'fa-file-video',
+            gz: 'fa-file-archive',
             zip: 'fa-file-archive',
-            txt: 'fa-file-alt',
-            js: 'fa-file-code'
+            css: 'fa-file-code',
+            html: 'fa-file-code',
+            js: 'fa-file-code',
+            txt: 'fa-file-alt'
         }
 
         Object.keys(testCases).map(extension => {

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,8 @@ import icons from '../src/icons'
 describe('icons', () => {
 
     it('returns_an_object_with_all_icons', () => {
-        assert.isAbove(Object.keys(icons).length, 1)
+        assert.equal(Object.keys(icons).length, 11)
+        assert.equal(Object.values(icons).length, 11)
     })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -104,7 +104,7 @@ describe('get_class_name_for_filename', () => {
             'spreadsheet.xls': 'fa-file-excel',
             'song.mp3': 'fa-file-audio',
             'song.mp4': 'fa-file-video',
-            'archive.zip': 'fa-file-zip',
+            'archive.zip': 'fa-file-archive',
             'script.js': 'fa-file-code'
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,8 @@ import {
     getIconForExtension,
     getExtensionForFilename,
     getClassNameForFilename,
-    getIconForFilename
+    getIconForFilename,
+    getClassNameForMimetype, getIconForMimetype
 } from '../src/index'
 import icons from '../src/icons'
 
@@ -118,5 +119,61 @@ describe('get_icon_for_filename', () => {
 
     it('returns_the_correct_icon_for_a_filename', () => {
         assert.equal('<i class="fa fa-file-image"></i>', getIconForFilename('image.jpg'))
+    })
+})
+
+describe('get_class_name_for_mimetype', () => {
+
+    it('returns_a_default_file_icon', () => {
+        assert.equal('fa-file', getClassNameForMimetype('example/mimetype'))
+    })
+
+    it('can_handle_other_cases', () => {
+        assert.equal('fa-file-image', getClassNameForMimetype('IMAGE/jpeg'))
+    })
+
+    it('returns_the_correct_class_name_for_a_mimetype', () => {
+        let testCases = {
+            'image/gif': 'fa-file-image',
+            'image/jpeg': 'fa-file-image',
+            'image/png': 'fa-file-image',
+            'application/pdf': 'fa-file-pdf',
+            'application/msword': 'fa-file-word',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'fa-file-word',
+            'application/mspowerpoint': 'fa-file-powerpoint',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'fa-file-powerpoint',
+            'application/msexcel': 'fa-file-excel',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'fa-file-excel',
+            'audio/aac': 'fa-file-audio',
+            'audio/wav': 'fa-file-audio',
+            'audio/mpeg': 'fa-file-audio',
+            'audio/mp4': 'fa-file-audio',
+            'audio/ogg': 'fa-file-audio',
+            'video/x-msvideo': 'fa-file-video',
+            'video/mpeg': 'fa-file-video',
+            'video/ogg': 'fa-file-video',
+            'video/quicktime': 'fa-file-video',
+            'video/webm': 'fa-file-video',
+            'application/gzip': 'fa-file-archive',
+            'application/zip': 'fa-file-archive',
+            'text/css': 'fa-file-code',
+            'text/html': 'fa-file-code',
+            'text/javascript': 'fa-file-code',
+            'application/javascript': 'fa-file-code',
+            'text/plain': 'fa-file-alt',
+            'text/richtext': 'fa-file-alt',
+            'text/rtf': 'fa-file-alt'
+        }
+
+        Object.keys(testCases).map(mimetype => {
+            assert.equal(testCases[mimetype], getClassNameForMimetype(mimetype))
+        })
+    })
+})
+
+describe('get_icon_for_mimetype', () => {
+
+    it('returns_the_correct_icon_for_a_mimetype', () => {
+        assert.equal('<i class="fa fa-file-image"></i>', getIconForMimetype('image/jpeg'))
     })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,8 @@ import {
     getExtensionForFilename,
     getClassNameForFilename,
     getIconForFilename,
-    getClassNameForMimetype, getIconForMimetype
+    getClassNameForMimetype,
+    getIconForMimetype
 } from '../src/index'
 import icons from '../src/icons'
 


### PR DESCRIPTION
fixes #9 #12 

I've also ...
* renamed the `archive` icon key - `zip` was too precise and also doesn't match the last part of the class-name.
* fixed and extended some unittests
* removed the `file` key from the `extensions` because it isn't an extension and the default is done by `|| icons.file`
* added the CSV icon https://fontawesome.com/icons/file-csv

So at all this could be a BC. 