### PR TITLE
Update badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Font Awesome Filetypes
 
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/spatie/font-awesome-filetypes.svg?style=flat-square)](https://travis-ci.org/spatie/font-awesome-filetypes)
 
 Helper to retrieve the Font Awesome 5 icon for a specific file extension.


### PR DESCRIPTION
If the bade doesn't load, this will still allow users to see what the license is. It is also beneficial for users who use screen readers.